### PR TITLE
Add configurable option for election directories, as well as PostgreSQL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ DB_USERNAME=root
 DB_PASSWORD=
 
 META_REPO=https://github.com/kalkayan/k8s.elections.meta.git
+ELECTION_DIR=elections
 META_DEPLOYMENT=local
 META_PATH=meta
 META_BRANCH=main

--- a/config.py
+++ b/config.py
@@ -58,6 +58,14 @@ if env('DB_CONNECTION') == 'mysql':
         port=env('DB_PORT', 3306),
         dbname=env('DB_DATABASE'),
     )
+elif env('DB_CONNECTION') == 'postgresql':
+    DATABASE_URL = "postgresql://{user}:{password}@{host}:{port}/{dbname}".format(
+        user=env('DB_USERNAME', 'root'),
+        password=env('DB_PASSWORD', ''),
+        host=env('DB_HOST', 'localhost'),
+        port=env('DB_PORT', 3306),
+        dbname=env('DB_DATABASE'),
+    )
 elif env('DB_CONNECTION') == 'sqlite':
     DATABASE_URL = "sqlite:///{path}".format(
         path=env('DB_PATH', os.path.join(
@@ -79,6 +87,7 @@ else:
 # - DEPLOYMENT : mode of deployment (local, sidecar)
 META = {
     'REMOTE': env('META_REPO'),
+    'ELECDIR': env('ELECTION_DIR'),
     'PATH': env('META_PATH', 'meta'),
     'DEPLOYMENT': env('META_DEPLOYMENT', 'local'),
     'BRANCH': env('META_BRANCH', 'main'),

--- a/elekto/models/meta.py
+++ b/elekto/models/meta.py
@@ -72,7 +72,7 @@ class Election(Meta):
             list: list of all the elections
         """
         meta = Meta(APP.config['META'])
-        path = os.path.join(meta.META, 'elections')
+        path = os.path.join(meta.META, meta.ELECDIR)
         keys = [k for k in os.listdir(
             path) if Election.is_elecdir(os.path.join(path, k))]
 

--- a/elekto/models/meta.py
+++ b/elekto/models/meta.py
@@ -33,6 +33,7 @@ class Meta:
 
     def __init__(self, config):
         self.META = os.path.abspath(config['PATH'])
+        self.ELECDIR = config['ELECDIR']
         self.REMOTE = config['REMOTE']
         self.BRANCH = config['BRANCH']
         self.SECRET = config['SECRET']
@@ -55,7 +56,7 @@ class Election(Meta):
 
     def __init__(self, key):
         Meta.__init__(self, APP.config['META'])
-        self.store = os.path.join(self.META, 'elections')
+        self.store = os.path.join(self.META, self.ELECDIR)
         self.path = os.path.join(self.store, key)
         self.key = key
         self.election = {}


### PR DESCRIPTION
This PR does two things:

1. Adds the ability to configure the host directory of "elections".  That is, the "elections" directory no longer needs to be in the repository root, but can be in an arbitrary subdirectory.
2. Adds PostgreSQL as a database option.
 
Please review!