### PR TITLE
Add simple HTTP 200 healh check endpoint at /health

### DIFF
--- a/elekto/controllers/public.py
+++ b/elekto/controllers/public.py
@@ -49,3 +49,8 @@ def public_election(eid):
     return F.render_template('views/public/elections_single.html',
                              election=election.get(),
                              candidates=candidates)
+                             
+@APP.route('/health')
+def health_check():
+    status_code = F.Response(status=200)
+    return status_code


### PR DESCRIPTION
This just adds a simple 200:OK health check endpoint, at the unauthenticated route of /health

At some point later, we probably want to build this out to actually check the status of the app, but this at least checks that it's running for now.


Signed-off-by: Josh Berkus <josh@agliodbs.com>