### PR TITLE
Tag the generated container with a fixed name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
+            type=ref,event=push
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
I am working on deploying elekto on a Openshift cluster, and the container image do not have a latest tag, so that make automating the deployment more complex than it should. 

This PR should create a 'main' tag (and maybe latest, doc is not clear) that allow to automatically update the container if needed.