### PR TITLE
Add a default value for GITHUB_REDIRECT

### DIFF
--- a/config.py
+++ b/config.py
@@ -101,6 +101,6 @@ META = {
 GITHUB = {
     'client_id': env('GITHUB_CLIENT_ID'),
     'client_secret': env('GITHUB_CLIENT_SECRET'),
-    'redirect': env('GITHUB_REDIRECT'),
+    'redirect': env('GITHUB_REDIRECT', '/oauth/github/callback'),
     'scope': 'user:login,name',
 }


### PR DESCRIPTION
Since that's only used to declare a route in the code, there is not
much reason to not have a default value