### PR TITLE
Handle non-default branches for metadata repository

### DIFF
--- a/elekto/models/meta.py
+++ b/elekto/models/meta.py
@@ -42,10 +42,10 @@ class Meta:
             ".format(self.META, self.META)
 
     def clone(self):
-        os.system('{} clone {} {}'.format(self.git, self.REMOTE, self.META))
+        os.system('{} clone -b {} -- {} {}'.format(self.git, self.BRANCH, self.REMOTE, self.META))
 
     def pull(self):
-        os.system('{} pull origin {}'.format(self.pref, self.BRANCH))
+        os.system('{} pull --ff-only origin {}'.format(self.pref, self.BRANCH))
 
 
 class Election(Meta):


### PR DESCRIPTION
This change updates the metadata class to check out the branch configured for the metadata repository when it clones the repository initially, and then to conduct only fast-forward pulls from that branch on updates.

Previously, the clone operation would check out the default branch for the metadata repository (typically "main" or "master"). When it then pulls updates on the configured branch, if that branch has diverged from the main branch, then the pull command attempts to make a merge commit. In a containerized runtime environment, the Git user data is not configured, so this commit attempt fails.