### PR TITLE
Replace all os.system() calls with suprocess.run()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.12-stretch
+FROM python:3.6.14-stretch
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.14-stretch
+FROM python:3.7-stretch
 
 WORKDIR /app
 

--- a/elekto/models/meta.py
+++ b/elekto/models/meta.py
@@ -16,6 +16,7 @@
 
 import os
 import random
+import subprocess
 import flask as F
 
 from datetime import datetime
@@ -38,14 +39,12 @@ class Meta:
         self.BRANCH = config['BRANCH']
         self.SECRET = config['SECRET']
         self.git = '/usr/bin/git'
-        self.pref = "/usr/bin/git --git-dir={}/.git --work-tree={}\
-            ".format(self.META, self.META)
 
     def clone(self):
-        os.system('{} clone -b {} -- {} {}'.format(self.git, self.BRANCH, self.REMOTE, self.META))
+        subprocess.run([self.git, 'clone', '-b', self.BRANCH, '--', self.REMOTE, self.META], check=True)
 
     def pull(self):
-        os.system('{} pull --ff-only origin {}'.format(self.pref, self.BRANCH))
+        subprocess.run([self.git, '--git-dir', '{}/.git'.format(self.META),'--work-tree', self.META, 'pull', '--ff-only', 'origin', self.BRANCH], check=True)
 
 
 class Election(Meta):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -15,6 +15,7 @@
 # Author(s):         Manish Sahani <rec.manish.sahani@gmail.com>
 
 import os
+import subprocess
 import sys
 import pytest
 import pandas as pd
@@ -37,14 +38,14 @@ from k8s_elections.models.sql import migrate  # noqa
 def client():
     # Generate Database
     db = os.path.abspath('./test.db')
-    os.system('touch {}'.format(db))
+    subprocess.run(['touch', db], check=True)
 
     with APP.test_client() as client:
         with APP.app_context():
             migrate(APP.config['DATABASE_URL'])
         yield client
 
-    os.system('rm {}'.format(db))
+    subprocess.run('rm', db)
     # os.system('rm -rf {}'.format(APP.config['META']['PATH']))
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -45,7 +45,7 @@ def client():
             migrate(APP.config['DATABASE_URL'])
         yield client
 
-    subprocess.run('rm', db)
+    os.unlink(db)
     # os.system('rm -rf {}'.format(APP.config['META']['PATH']))
 
 


### PR DESCRIPTION
Modernize code by replacing os.system with subprocess.

Also allows trapping more kinds of potential errors with cloning and syncing.

Fixes #73

Addresses some of the issues in #75.

Tag @mscherer @kalkayan 