### PR TITLE
Scope requests to view and edit vote record to the specified election

### DIFF
--- a/elekto/controllers/elections.py
+++ b/elekto/controllers/elections.py
@@ -149,7 +149,7 @@ def elections_view(eid):
     election = meta.Election(eid)
     voters = election.voters()
     e = SESSION.query(Election).filter_by(key=eid).first()
-    voter = SESSION.query(Voter).filter_by(user_id=F.g.user.id).first()
+    voter = SESSION.query(Voter).filter_by(user_id=F.g.user.id,election_id=e.id).first()
 
     passcode = F.request.form["password"]
 
@@ -175,7 +175,7 @@ def elections_view(eid):
 def elections_edit(eid):
     election = meta.Election(eid)
     e = SESSION.query(Election).filter_by(key=eid).first()
-    voter = SESSION.query(Voter).filter_by(user_id=F.g.user.id).first()
+    voter = SESSION.query(Voter).filter_by(user_id=F.g.user.id,election_id=e.id).first()
 
     passcode = F.request.form["password"]
 


### PR DESCRIPTION
The controllers to view and to edit a voter's submission in an election now search for that vote record within the scope of the ID of the election.

Otherwise, the controller will find the first vote that user submitted for any election in the system and attempt to decrypt that vote using the supplied password.

This issue arose as the Cloud Foundry community started conducting this year's Technical Oversight Committee election with our Elekto deployment that still had records from the 2022 election. I cast my own vote only to find that the only vote record I could retrieve was my vote from that previous election, with the password I had set for it at the time of submission.