### PR TITLE
Fix release-image.yml

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   push_to_registry:
     name: Push Docker image to GHCR


### PR DESCRIPTION
After moving the workflow to a new file, it seems the environment wasn't copied. So the images variable was set to "/", and so it failed with the error: ```buildx failed with: ERROR: invalid tag "/:0.6.6": invalid reference format"```