### PR TITLE
Show "No profile submitted." when candidate profile is empty

### DIFF
--- a/elekto/models/meta.py
+++ b/elekto/models/meta.py
@@ -168,8 +168,8 @@ class Election(Meta):
         md = open(path).read()
         candidate = utils.extract_candidate_info(md)
         candidate['key'] = cid
-        candidate['description'] = utils.parse_md(
-            utils.extract_candidate_description(md), False)
+        description = utils.extract_candidate_description(md)
+        candidate['description'] = utils.parse_md(description, False) if description.strip() else None
         # return only the candidate optional fields that are listed in show_candidate_fields
         # unfilled fields are returned as '' so the label still displays
         candidate['fields'] = self.showfields()

--- a/elekto/templates/views/elections/candidate.html
+++ b/elekto/templates/views/elections/candidate.html
@@ -29,7 +29,11 @@
     </div>
     <div class="space--md  pb-1rem">
         <div class="description space-lr">
-            {{ candidate['description'] | safe }}
+            {% if candidate['description'] %}
+                {{ candidate['description'] | safe }}
+            {% else %}
+                <p class="text-muted"><em>No profile submitted.</em></p>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/test/controllers/test_elections.py
+++ b/test/controllers/test_elections.py
@@ -256,8 +256,46 @@ def test_elections_candidate(client: FlaskClient, load_metadir):
     for expected_subtitle, subtitle in zip(expected_subtitles, subtitles):
         assert subtitle.text.strip() == expected_subtitle
 
+
     description_text = soup.find('div', attrs={'class': 'description space-lr'}).text.strip()
     assert description_text == 'Davanum Srinivas is a current member of the Steering Committee, and has been a member of the CNCF TOC.'
+
+
+def test_elections_candidate_empty_profile(client: FlaskClient, load_metadir, metadir):
+    """
+    Regression test for https://github.com/elekto-dev/elekto/issues/85
+
+    When a candidate profile file has a valid YAML header but an empty body,
+    visiting the candidate profile page should render the profile page normally
+    with a "No profile submitted." message instead of raising a server error.
+    """
+    import os
+    provision_session(client, token='...')
+
+    # Write a candidate file with a valid header but no body to the test metadir.
+    empty_profile_path = os.path.join(str(metadir), 'elections', '2021', 'GB', 'candidate-emptyprofile.md')
+    with open(empty_profile_path, 'w') as f:
+        f.write(
+            "---\n"
+            "name: Empty Profile Candidate\n"
+            "ID: emptyprofile\n"
+            "info:\n"
+            "  - employer: N/A\n"
+            "---\n"
+        )
+
+    response = client.get('/app/elections/2021---GB/candidates/emptyprofile')
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.data, 'html.parser')
+    # The candidate profile page should render normally.
+    title_text = soup.find('h1', attrs={'class': 'banner-title space-lr'}).text.strip()
+    assert title_text == 'Empty Profile Candidate'
+
+    # The description area should show the "No profile submitted." placeholder.
+    description_div = soup.find('div', attrs={'class': 'description space-lr'})
+    assert description_div is not None
+    assert 'No profile submitted.' in description_div.text
 
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

This PR fixes issue #85 by handling candidate profiles that contain a valid YAML header but no profile content.

Instead of rendering an empty page or causing an error, the candidate profile page now displays a friendly **"No profile submitted."** message.

## Changes

* Normalize empty or whitespace-only candidate descriptions to `None` in `meta.py`.
* Update the candidate profile template to display **"No profile submitted."** when no description is available.
* Add a regression test covering candidate profiles with an empty body.

## Testing

Ran the following tests successfully:

* `test/controllers/test_elections.py::test_elections_candidate`
* `test/controllers/test_elections.py::test_elections_candidate_empty_profile`

Fixes #85
