### PR TITLE
Use past tense for completed elections in voting info

### DIFF
--- a/elekto/templates/views/elections/single.html
+++ b/elekto/templates/views/elections/single.html
@@ -64,8 +64,16 @@
                   You have not yet voted in this election.
               {% endif %}
           {% endif %}
-            Voting starts at <b>{{ election['start_datetime'] }} UTC</b> and ends at
-            <b>{{ election['end_datetime'] }} UTC</b>.
+            {% if election['status'] == 'completed' %}
+                Voting started at <b>{{ election['start_datetime'] }} UTC</b> and ended at
+                <b>{{ election['end_datetime'] }} UTC</b>.
+            {% elif election['status'] == 'upcoming' %}
+                Voting starts at <b>{{ election['start_datetime'] }} UTC</b> and ends at
+                <b>{{ election['end_datetime'] }} UTC</b>.
+            {% else %}
+                Voting started at <b>{{ election['start_datetime'] }} UTC</b> and is open until
+                <b>{{ election['end_datetime'] }} UTC</b>.
+            {% endif %}
             {% if g.user.username not in voters['eligible_voters'] %}
                 If you wish to participate in the election, please fill the
                 <a href="{{ url_for('elections_exception', eid=election['key']) }}"><b>exception form</b></a>

--- a/elekto/templates/views/elections/view_ballots.html
+++ b/elekto/templates/views/elections/view_ballots.html
@@ -61,8 +61,16 @@
                   You have not yet voted in this election.
               {% endif %}
           {% endif %}
-            Voting starts at <b>{{ election['start_datetime'] }} UTC</b> and ends at
-            <b>{{ election['end_datetime'] }} UTC</b>.
+            {% if election['status'] == 'completed' %}
+                Voting started at <b>{{ election['start_datetime'] }} UTC</b> and ended at
+                <b>{{ election['end_datetime'] }} UTC</b>.
+            {% elif election['status'] == 'upcoming' %}
+                Voting starts at <b>{{ election['start_datetime'] }} UTC</b> and ends at
+                <b>{{ election['end_datetime'] }} UTC</b>.
+            {% else %}
+                Voting started at <b>{{ election['start_datetime'] }} UTC</b> and is open until
+                <b>{{ election['end_datetime'] }} UTC</b>.
+            {% endif %}
             {% if g.user.username not in voters['eligible_voters'] %}
                 If you wish to participate in the election, please fill the
                 <a href="{{ url_for('elections_exception', eid=election['key']) }}"><b>exception form</b></a>


### PR DESCRIPTION
Fixes #79

Changes the 'Voting starts at... and ends at...' text to use past tense for completed elections:

- **Completed**: 'Voting started at... and ended at...'
- **Running**: 'Voting started at... and is open until...'
- **Upcoming**: 'Voting starts at... and ends at...' (unchanged)

Updated in both `single.html` and `view_ballots.html` templates.