### PR TITLE
Skip rendering empty candidate fields

### DIFF
--- a/elekto/templates/views/elections/candidate.html
+++ b/elekto/templates/views/elections/candidate.html
@@ -22,9 +22,11 @@
             <small class="badge badge-green" style="text-transform: none;">{{ candidate['ID'] }}</small> | <span>Running for {{ election['name'] }}</span>
         </p>
         {% for fieldname, info in candidate['fields'].items() %}
+        {% if info %}
         <p class="banner-subtitle space-lr">
             <small class="badge badge-green" style="text-transform: none;">{{ fieldname }}</small> | <span>{{ info }}</span>
         </p>
+        {% endif %}
         {% endfor %}
     </div>
     <div class="space--md  pb-1rem">


### PR DESCRIPTION
Fixes #80

When a candidate doesn't provide a value for a field listed in `show_candidate_fields` (e.g. twitter, slack), the field was still rendered with an empty `<span>`. Now empty-valued fields are skipped entirely in the template.

Note: does not address the related case where `show_candidate_fields` is `None` (#98).