### PR TITLE
Display Elekto version in sidebar UI

### DIFF
--- a/elekto/__init__.py
+++ b/elekto/__init__.py
@@ -18,6 +18,7 @@ import flask as F
 from flask_wtf.csrf import CSRFProtect
 
 from elekto.models import sql
+from elekto.version import __version__
 
 APP = F.Flask(__name__)
 APP.config.from_object('config')
@@ -47,6 +48,11 @@ def before_request():
 def destroy_session(exception=None):
     # Remove the database session
     SESSION.remove()
+
+
+@APP.context_processor
+def inject_version():
+    return dict(elekto_version=__version__)
 
 
 ####

--- a/elekto/__init__.py
+++ b/elekto/__init__.py
@@ -14,6 +14,8 @@
 #
 # Author(s):         Manish Sahani <rec.manish.sahani@gmail.com>
 
+import datetime
+
 import flask as F
 from flask_wtf.csrf import CSRFProtect
 
@@ -52,7 +54,8 @@ def destroy_session(exception=None):
 
 @APP.context_processor
 def inject_version():
-    return dict(elekto_version=__version__)
+    return dict(elekto_version=__version__,
+                current_year=datetime.datetime.now().year)
 
 
 ####

--- a/elekto/templates/components/sidebar.html
+++ b/elekto/templates/components/sidebar.html
@@ -26,6 +26,6 @@
     {% endfor %}
 
     <div class="sidebar-item sidebar__footer">
-        copyright 2020 © elekto
+        Elekto v{{ elekto_version }} &mdash; copyright 2020
     </div>
 </div>

--- a/elekto/templates/components/sidebar.html
+++ b/elekto/templates/components/sidebar.html
@@ -26,6 +26,6 @@
     {% endfor %}
 
     <div class="sidebar-item sidebar__footer">
-        Elekto v{{ elekto_version }} &mdash; copyright 2020
+        Elekto v{{ elekto_version }} &mdash; copyright 2020&ndash;{{ current_year }} &copy; elekto
     </div>
 </div>

--- a/elekto/version.py
+++ b/elekto/version.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("elekto")
+except PackageNotFoundError:
+    __version__ = "0.0.0"


### PR DESCRIPTION
Adds a Flask context processor that injects `elekto_version` into all templates, and updates the sidebar footer to display it.

The version is read from `importlib.metadata` which resolves via `setuptools-scm` from git tags. When the package is not installed (dev without `pip install -e .`), it falls back to `0.0.0`.

The version now appears in the sidebar on every authenticated page:

> Elekto v0.8.0 — copyright 2020

Fixes #96

Depends on #136 